### PR TITLE
Adds linux build.sh and adds a prettier configuration

### DIFF
--- a/private-pilot-extension/.prettierrc
+++ b/private-pilot-extension/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "printWidth": 80,
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "endOfLine": "lf"
+}

--- a/private-pilot-extension/.prettierrc
+++ b/private-pilot-extension/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 80,
+    "printWidth": 100,
     "tabWidth": 2,
     "useTabs": false,
     "semi": true,

--- a/private-pilot-extension/build.bat
+++ b/private-pilot-extension/build.bat
@@ -1,5 +1,10 @@
+where npm >nul 2>nul || (
+    echo npm is not installed. Aborting.
+    exit /b 1
+)
+
 @echo off
 call npm install
 call npm run compile
-call vsce package
+call npx vsce package
 echo All commands executed successfully!

--- a/private-pilot-extension/build.sh
+++ b/private-pilot-extension/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+command -v npm >/dev/null 2>&1 || { echo "npm is not installed. Aborting."; exit 1; }
+
+npm install
+npm run compile
+npx vsce package
+
+echo "All commands executed successfully!"


### PR DESCRIPTION
This PR adds a `build.sh` script for Linux and improves the Windows batch script by checking for `npm`.  
It also introduces a Prettier config for consistent code formatting.

Please retest the Windows batch file — not sure if `@echo off` is needed, and confirm if `vsce` installs correctly like in the Linux script.

After merging, please reformat the TypeScript files.