### PR TITLE
Add generic LLM provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PrivatePilot
 IDE extension for private coding 
 
-**Private Pilot** is a powerful VSCode extension designed to enhance developer productivity by integrating AI-driven assistance directly within the Visual Studio Code IDE. Leveraging the Ollama AI backend, Private Pilot provides real-time code suggestions, automated bug fixes, intelligent code commenting, and an interactive chat interface to streamline your coding workflow.
+**Private Pilot** is a powerful VSCode extension designed to enhance developer productivity by integrating AI-driven assistance directly within the Visual Studio Code IDE. It can connect to multiple language models—including Ollama, OpenAI, Grok, and Claude—to provide real-time code suggestions, automated bug fixes, intelligent code commenting, and an interactive chat interface to streamline your workflow.
 
 
 <img src="media/privatepilot2.png" alt="Private Pilot Logo" width="200" height="200" />

--- a/private-pilot-extension/README.md
+++ b/private-pilot-extension/README.md
@@ -1,7 +1,7 @@
 # Private Pilot VSCode Extension
 
 ## Overview
-**Private Pilot** is a powerful VSCode extension designed to enhance developer productivity by integrating AI-driven assistance directly within the Visual Studio Code IDE. Leveraging the Ollama AI backend, Private Pilot provides real-time code suggestions, automated bug fixes, intelligent code commenting, and an interactive chat interface to streamline your coding workflow.
+**Private Pilot** is a powerful VSCode extension designed to enhance developer productivity by integrating AI-driven assistance directly within the Visual Studio Code IDE. It can communicate with multiple large language model providers—including Ollama, OpenAI, Grok, and Claude—to deliver real-time code suggestions, automated bug fixes, intelligent code commenting, and an interactive chat interface to streamline your coding workflow.
 
 **Version:** 0.3.0
 
@@ -35,7 +35,7 @@ Alternatively, install via the [VSCode Marketplace](https://marketplace.visualst
    - Generate comments or documentation by selecting code and using context-aware prompts.
 
 ## Configuration
-- **Ollama Backend**: Ensure the Ollama backend is running and accessible. Configure the endpoint in the extension settings if needed.
+- **Model Provider**: Choose between `ollama`, `openai`, `grok`, or `claude` in the extension settings. Each provider has its own endpoint and API key fields.
 - **Verbosity Levels**: Customize the level of detail for AI-generated comments in the extension settings.
 - **Project Management Tools**: Link your Jira, GitHub, or Trello accounts in the settings for seamless integration.
 
@@ -43,7 +43,7 @@ Alternatively, install via the [VSCode Marketplace](https://marketplace.visualst
 - **VSCode**: Version 1.60.0 or later
 - **Node.js**: Required for development and building the extension
 - **TypeScript**: Used for development
-- **Ollama Backend**: Required for AI functionality
+- **LLM Backend**: Ensure your chosen provider (Ollama, OpenAI, Grok, or Claude) is reachable. Some providers require an API key.
 
 ## Development
 To contribute or customize the extension:

--- a/private-pilot-extension/package.json
+++ b/private-pilot-extension/package.json
@@ -153,6 +153,12 @@
     "configuration": {
       "title": "Code Rewriter",
       "properties": {
+        "codeRewriter.provider": {
+          "type": "string",
+          "enum": ["ollama", "openai", "grok", "claude"],
+          "default": "ollama",
+          "description": "LLM provider to use"
+        },
         "codeRewriter.ollamaEndpoint": {
           "type": "string",
           "default": "http://localhost:11434/api/generate",
@@ -162,6 +168,51 @@
           "type": "string",
           "default": "llama2",
           "description": "Ollama model to use for code improvement"
+        },
+        "codeRewriter.openaiApiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for OpenAI"
+        },
+        "codeRewriter.openaiModel": {
+          "type": "string",
+          "default": "gpt-3.5-turbo",
+          "description": "OpenAI model"
+        },
+        "codeRewriter.openaiEndpoint": {
+          "type": "string",
+          "default": "https://api.openai.com/v1/chat/completions",
+          "description": "OpenAI endpoint"
+        },
+        "codeRewriter.grokEndpoint": {
+          "type": "string",
+          "default": "",
+          "description": "Endpoint for Grok API"
+        },
+        "codeRewriter.grokApiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for Grok"
+        },
+        "codeRewriter.grokModel": {
+          "type": "string",
+          "default": "latest",
+          "description": "Grok model"
+        },
+        "codeRewriter.claudeEndpoint": {
+          "type": "string",
+          "default": "",
+          "description": "Endpoint for Claude API"
+        },
+        "codeRewriter.claudeApiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for Claude"
+        },
+        "codeRewriter.claudeModel": {
+          "type": "string",
+          "default": "claude-3-opus-20240229",
+          "description": "Claude model"
         }
       }
     }

--- a/private-pilot-extension/src/modelProviders.ts
+++ b/private-pilot-extension/src/modelProviders.ts
@@ -1,0 +1,139 @@
+import axios from 'axios';
+import * as vscode from 'vscode';
+import { extractCodeFromResponse, getFallbackURL, FALLBACK_MODEL } from './common';
+
+export interface ModelProvider {
+  generate(prompt: string): Promise<string>;
+}
+
+export class OllamaProvider implements ModelProvider {
+  constructor(private endpoint: string, private model: string) {}
+
+  async generate(prompt: string): Promise<string> {
+    const response = await axios.post(
+      this.endpoint,
+      { model: this.model, prompt, stream: false },
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+
+    if (response.data && response.data.response) {
+      return extractCodeFromResponse(response.data.response);
+    }
+    throw new Error('Invalid response from Ollama');
+  }
+}
+
+export class OpenAIProvider implements ModelProvider {
+  constructor(
+    private apiKey: string,
+    private model: string,
+    private endpoint: string = 'https://api.openai.com/v1/chat/completions',
+  ) {}
+
+  async generate(prompt: string): Promise<string> {
+    const response = await axios.post(
+      this.endpoint,
+      {
+        model: this.model,
+        messages: [{ role: 'user', content: prompt }],
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      },
+    );
+
+    if (response.data?.choices?.length) {
+      const content = response.data.choices[0].message.content;
+      return extractCodeFromResponse(content);
+    }
+    throw new Error('Invalid response from OpenAI');
+  }
+}
+
+export class GrokProvider implements ModelProvider {
+  constructor(
+    private endpoint: string,
+    private apiKey: string,
+    private model: string,
+  ) {}
+
+  async generate(prompt: string): Promise<string> {
+    const response = await axios.post(
+      this.endpoint,
+      { model: this.model, prompt },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      },
+    );
+
+    if (response.data && response.data.response) {
+      return extractCodeFromResponse(response.data.response);
+    }
+    throw new Error('Invalid response from Grok');
+  }
+}
+
+export class ClaudeProvider implements ModelProvider {
+  constructor(
+    private endpoint: string,
+    private apiKey: string,
+    private model: string,
+  ) {}
+
+  async generate(prompt: string): Promise<string> {
+    const response = await axios.post(
+      this.endpoint,
+      { model: this.model, prompt },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      },
+    );
+
+    if (response.data && (response.data.completion || response.data.response)) {
+      const content = response.data.completion ?? response.data.response;
+      return extractCodeFromResponse(content);
+    }
+    throw new Error('Invalid response from Claude');
+  }
+}
+
+export function getModelProvider(): ModelProvider {
+  const config = vscode.workspace.getConfiguration('codeRewriter');
+  const provider = (config.get<string>('provider') || 'ollama').toLowerCase();
+
+  switch (provider) {
+    case 'openai':
+      return new OpenAIProvider(
+        config.get<string>('openaiApiKey') || '',
+        config.get<string>('openaiModel') || 'gpt-3.5-turbo',
+        config.get<string>('openaiEndpoint') || 'https://api.openai.com/v1/chat/completions',
+      );
+    case 'grok':
+      return new GrokProvider(
+        config.get<string>('grokEndpoint') || '',
+        config.get<string>('grokApiKey') || '',
+        config.get<string>('grokModel') || 'latest',
+      );
+    case 'claude':
+      return new ClaudeProvider(
+        config.get<string>('claudeEndpoint') || '',
+        config.get<string>('claudeApiKey') || '',
+        config.get<string>('claudeModel') || 'claude-3-opus-20240229',
+      );
+    case 'ollama':
+    default:
+      return new OllamaProvider(
+        config.get<string>('ollamaEndpoint') || getFallbackURL('api/generate'),
+        config.get<string>('ollamaModel') || FALLBACK_MODEL,
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- add ModelProvider interface with implementations for Ollama, OpenAI, Grok and Claude
- use new provider in extension commands
- rename rewrite handler to `handleModelRequest`
- expose provider options in extension configuration
- update documentation to explain multi-model support

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode')*
- `npm install` *(fails: Exit handler never called)*